### PR TITLE
Change JSON keys casing to camelCase

### DIFF
--- a/app/models/item.py
+++ b/app/models/item.py
@@ -19,12 +19,12 @@ class Item(db.Model):
     def to_dict(self):
         return {
             'id': self.id,
-            'user_id': self.user_id,
+            'userId': self.user_id,
             'name': self.name,
             'description': self.description,
             'image': self.image,
             'price': self.price,
             'stock': self.stock,
-            'created_at': self.created_at,
-            'updated_at': self.updated_at
+            'createdAt': self.created_at,
+            'updatedAt': self.updated_at
         }


### PR DESCRIPTION
As the data returned from our API is JSON, I felt it would make more sense for the keys to be in camelCase instead of snake_case. This changes the keys in the `Item`'s `to_dict` method to return camelCased keys.