### PR TITLE
Prevent API redirect when unauthed in auth required route

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, render_template, request, session, redirect
+from flask import Flask, render_template, request, session, redirect, abort
 from flask_cors import CORS
 from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect, generate_csrf
@@ -19,12 +19,14 @@ app = Flask(__name__)
 
 # Setup login manager
 login = LoginManager(app)
-login.login_view = 'auth.unauthorized'
-
 
 @login.user_loader
 def load_user(id):
     return User.query.get(int(id))
+
+@login.unauthorized_handler
+def unauthorized():
+    return {}, 401
 
 
 # Tell flask about our seed commands

--- a/app/api/auth_routes.py
+++ b/app/api/auth_routes.py
@@ -72,11 +72,3 @@ def sign_up():
         login_user(user)
         return user.to_dict()
     return {'errors': validation_errors_to_error_messages(form.errors)}, 401
-
-
-@auth_routes.route('/unauthorized')
-def unauthorized():
-    """
-    Returns unauthorized JSON when flask-login authentication fails
-    """
-    return {'errors': ['Unauthorized']}, 401


### PR DESCRIPTION
Currently, when a user is not authorized when attempting to go to an API route, the API route is redirected to `api/auth/unauthorized`. This prevents that redirect and instead just returns a 401. I don't believe this affects anything currently implemented and just makes the network tab look clearer.