### PR TITLE
Fix auth modal not closing on login/register success

### DIFF
--- a/react-app/src/components/auth/AuthModals.js
+++ b/react-app/src/components/auth/AuthModals.js
@@ -21,8 +21,10 @@ const AuthModals = () => {
   return (
     <Dialog onClose={close}>
       <FormWrapper>
-        {loginVisible && <LoginForm toSignUp={switchForms} />}
-        {signupVisible && <SignUpForm toLogin={switchForms} />}
+        {loginVisible && <LoginForm onSuccess={close} toSignUp={switchForms} />}
+        {signupVisible && (
+          <SignUpForm onSuccess={close} toLogin={switchForms} />
+        )}
       </FormWrapper>
     </Dialog>
   );

--- a/react-app/src/components/auth/LoginForm.js
+++ b/react-app/src/components/auth/LoginForm.js
@@ -10,7 +10,7 @@ const Actions = styled.div`
   padding-top: 16px;
 `;
 
-const LoginForm = ({ toSignUp }) => {
+const LoginForm = ({ onSuccess, toSignUp }) => {
   const [errors, setErrors] = useState([]);
   const [cred, setCred] = useState('');
   const [password, setPassword] = useState('');
@@ -20,7 +20,8 @@ const LoginForm = ({ toSignUp }) => {
   const onLogin = async (e) => {
     e.preventDefault();
     dispatch(login({ cred, password }))
-      .unwrap().then()
+      .unwrap()
+      .then(onSuccess)
       .catch((data) => {
         if (data) {
           setErrors(data);
@@ -30,8 +31,8 @@ const LoginForm = ({ toSignUp }) => {
 
   const handleLoginDemo = async (e) => {
     e.preventDefault();
-    dispatch(loginDemo())
-  }
+    dispatch(loginDemo()).unwrap().then(onSuccess);
+  };
 
   const updateCred = (e) => {
     setCred(e.target.value);

--- a/react-app/src/components/auth/SignUpForm.js
+++ b/react-app/src/components/auth/SignUpForm.js
@@ -10,7 +10,7 @@ const Actions = styled.div`
   padding-top: 16px;
 `;
 
-const SignUpForm = ({ toLogin }) => {
+const SignUpForm = ({ onSuccess, toLogin }) => {
   const [errors, setErrors] = useState([]);
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
@@ -23,11 +23,14 @@ const SignUpForm = ({ toLogin }) => {
   const onSignUp = async (e) => {
     e.preventDefault();
     if (password === repeatPassword) {
-      dispatch(signUp({ username, email, password, location })).unwrap().catch((data) => {
-        if (data) {
-          setErrors(data);
-        }
-      });
+      dispatch(signUp({ username, email, password, location }))
+        .unwrap()
+        .then(onSuccess)
+        .catch((data) => {
+          if (data) {
+            setErrors(data);
+          }
+        });
     }
   };
 


### PR DESCRIPTION
When the user logged in from a registration or login success, the modal was still displaying. This fixes the issue by closing the modal on a success.