### PR TITLE
Fix search button background not filling input

### DIFF
--- a/react-app/src/components/NavBar.js
+++ b/react-app/src/components/NavBar.js
@@ -80,6 +80,7 @@ const StyledNavElement = styled.header`
       & + ${IconButton} {
         border-bottom-left-radius: 0;
         border-top-left-radius: 0;
+        line-height: inherit;
         padding-bottom: 12px;
         padding-left: 15px;
         padding-right: 21px;


### PR DESCRIPTION
The search button's hover background color and focus background color did not properly cover the input box. This was caused by a change to the `IconButton`'s `line-height` styling.