### PR TITLE
Allow user to adjust quantity of cart items

### DIFF
--- a/app/api/cart_routes.py
+++ b/app/api/cart_routes.py
@@ -36,6 +36,24 @@ def add_cart_item():
         return cart_item.to_dict()
     return {"errors": validation_errors_to_error_messages(form.errors)}, 400
 
+@cart_routes.route('/<int:item_id>', methods=['PATCH'])
+@login_required
+def update_cart_item_quantity(item_id):
+    form = CartItemForm()
+    form['csrf_token'].data = request.cookies['csrf_token']
+    form['itemId'].data = item_id
+    if form.validate_on_submit():
+        cart_item = CartItem.query.filter(CartItem.user_id == current_user.id, CartItem.item_id == item_id).first()
+        
+        if not cart_item:
+            return {"errors": ['Could not find the cart item for the current user']}, 400
+
+        cart_item.quantity = form.data['quantity']
+        db.session.add(cart_item)
+        db.session.commit()
+        return cart_item.to_dict()
+    return {"errors": validation_errors_to_error_messages(form.errors)}, 400
+
 @cart_routes.route('/<int:item_id>', methods=['DELETE'])
 @login_required
 def remove_cart_item(item_id):

--- a/app/forms/cart_item_form.py
+++ b/app/forms/cart_item_form.py
@@ -10,7 +10,11 @@ def item_exists(form, field):
     if not item:
         raise ValidationError('Item provided not found')
 
+def above_zero(form, field):
+    quantity = field.data
+    if quantity <= 0:
+        raise ValidationError('Quantity must 1 or greater')
 
 class CartItemForm(FlaskForm):
     itemId = IntegerField(validators=[DataRequired(), item_exists])
-    quantity = IntegerField(validators=[DataRequired()])
+    quantity = IntegerField(validators=[DataRequired(), above_zero])

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
     "http-proxy-middleware": "^1.0.5",
+    "lodash.debounce": "^4.0.8",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/react-app/src/components/cart/CartListItem.js
+++ b/react-app/src/components/cart/CartListItem.js
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import { removeCartItem } from "../../store/cart-items";
 import Button from "../common/Button";
+import QuantitySelector from "./QuantitySelector";
 
 const CartListItemRoot = styled.li`
   display: flex;
@@ -63,7 +64,10 @@ const CartListItem = ({ imgSrc, itemId, name, price, quantity }) => {
             <h3>{name}</h3>
           </Link>
           <div className="actions">
-            <div>Quantity: {quantity}</div>
+            <QuantitySelector
+              value={quantity}
+              onChange={(newValue) => console.log(newValue)}
+            />
             <Button variant="text" onClick={handleRemove}>
               Remove
             </Button>

--- a/react-app/src/components/cart/CartListItem.js
+++ b/react-app/src/components/cart/CartListItem.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { removeCartItem } from "../../store/cart-items";
+import { changeCartItemQuantity, removeCartItem } from "../../store/cart-items";
 import Button from "../common/Button";
 import QuantitySelector from "./QuantitySelector";
 
@@ -51,6 +51,13 @@ const CartListItemRoot = styled.li`
 const CartListItem = ({ imgSrc, itemId, name, price, quantity }) => {
   const dispatch = useDispatch();
 
+  const handleQuantityChange = async (newValue) => {
+    if (newValue === quantity) {
+      return;
+    }
+    await dispatch(changeCartItemQuantity({ itemId, quantity: newValue }));
+  };
+
   const handleRemove = async () => {
     await dispatch(removeCartItem(itemId));
   };
@@ -66,7 +73,7 @@ const CartListItem = ({ imgSrc, itemId, name, price, quantity }) => {
           <div className="actions">
             <QuantitySelector
               value={quantity}
-              onChange={(newValue) => console.log(newValue)}
+              onChange={handleQuantityChange}
             />
             <Button variant="text" onClick={handleRemove}>
               Remove

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -3,15 +3,44 @@ import debounce from "lodash.debounce";
 import styled from "styled-components";
 import { useEffect, useMemo, useState } from "react";
 
+import IconButton from "../common/IconButton";
+
 const maximumCharacters = 3;
 
 const QuantitySelectorRoot = styled.div`
   position: relative;
 
   input {
+    border: 2px solid #000;
+    border-radius: ${(props) => props.theme.borderRadius.button}px;
     box-sizing: content-box;
+    padding: 6px 4ch;
     text-align: center;
     width: ${maximumCharacters}ch;
+  }
+
+  .decrement,
+  .increment {
+    border-radius: ${(props) => props.theme.borderRadius.button}px;
+    box-sizing: content-box;
+    height: 100%;
+    padding: 0 2px;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 3ch;
+  }
+
+  .decrement {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+    left: 0;
+  }
+
+  .increment {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    right: 0;
   }
 `;
 
@@ -108,9 +137,13 @@ const QuantitySelector = ({ onChange, value }) => {
 
   return (
     <QuantitySelectorRoot>
-      <button type="button" onClick={() => handleButtonClick(-1)}>
+      <IconButton
+        type="button"
+        className="decrement"
+        onClick={() => handleButtonClick(-1)}
+      >
         -
-      </button>
+      </IconButton>
       <input
         type="text"
         value={currentValue}
@@ -120,9 +153,13 @@ const QuantitySelector = ({ onChange, value }) => {
           handleUpDown(e);
         }}
       />
-      <button type="button" onClick={() => handleButtonClick(1)}>
+      <IconButton
+        type="button"
+        className="increment"
+        onClick={() => handleButtonClick(1)}
+      >
         +
-      </button>
+      </IconButton>
     </QuantitySelectorRoot>
   );
 };

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -81,6 +81,10 @@ const QuantitySelector = ({ onChange, value }) => {
       return updateValue("1");
     }
 
+    if (newValue.length > maximumCharacters) {
+      return updateValue(getMaxValueString());
+    }
+
     setCurrentValue(newValue);
     if (isValidValue(newValue)) {
       debouncedOnChange(parseInt(newValue));
@@ -88,10 +92,6 @@ const QuantitySelector = ({ onChange, value }) => {
   };
 
   const handleChange = (e) => {
-    // Prevent more than 3
-    if (e.target.value.length > maximumCharacters) {
-      return updateValue(getMaxValueString());
-    }
     updateValue(e.target.value);
   };
 
@@ -101,12 +101,7 @@ const QuantitySelector = ({ onChange, value }) => {
     }
     const parsedValue = parseInt(currentValue, 10);
     const newValue = parsedValue + modifier;
-
-    let newValueStr = String(newValue);
-    if (newValueStr.length > maximumCharacters) {
-      newValueStr = getMaxValueString();
-    }
-    updateValue(newValueStr);
+    updateValue(String(newValue));
   };
 
   /**

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -76,6 +76,11 @@ const QuantitySelector = ({ onChange, value }) => {
   }, [value]);
 
   const updateValue = (newValue) => {
+    // Prevent value going below 1
+    if (isValidValue(newValue) && parseInt(newValue, 10) <= 0) {
+      return updateValue("1");
+    }
+
     setCurrentValue(newValue);
     if (isValidValue(newValue)) {
       debouncedOnChange(parseInt(newValue));
@@ -96,11 +101,6 @@ const QuantitySelector = ({ onChange, value }) => {
     }
     const parsedValue = parseInt(currentValue, 10);
     const newValue = parsedValue + modifier;
-
-    // Prevent value going below 1
-    if (newValue <= 0) {
-      return updateValue("1");
-    }
 
     let newValueStr = String(newValue);
     if (newValueStr.length > maximumCharacters) {

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -83,7 +83,7 @@ const QuantitySelector = ({ onChange, value }) => {
   const filterKeyPresses = (event) => {
     if (/\d/.test(event.key)) {
       return;
-    } else if (/(backspace|tab)/i.test(event.code)) {
+    } else if (/(backspace|delete|tab)/i.test(event.code)) {
       return;
     } else if (event.ctrlKey && event.key === "a") {
       return;

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -51,6 +51,14 @@ const isValidValue = (value) => {
   return /^\d+$/.test(value);
 };
 
+const getMaxValueString = () => {
+  let maxValueString = "9";
+  for (let i = 1; i < maximumCharacters; i++) {
+    maxValueString += "9";
+  }
+  return maxValueString;
+};
+
 /**
  * @param {{
  *   onChange: (newValue) => void;
@@ -77,7 +85,7 @@ const QuantitySelector = ({ onChange, value }) => {
   const handleChange = (e) => {
     // Prevent more than 3
     if (e.target.value.length > maximumCharacters) {
-      return;
+      return updateValue(getMaxValueString());
     }
     updateValue(e.target.value);
   };
@@ -96,10 +104,7 @@ const QuantitySelector = ({ onChange, value }) => {
 
     let newValueStr = String(newValue);
     if (newValueStr.length > maximumCharacters) {
-      newValueStr = "9";
-      for (let i = 1; i < maximumCharacters; i++) {
-        newValueStr += "9";
-      }
+      newValueStr = getMaxValueString();
     }
     updateValue(newValueStr);
   };

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -3,8 +3,16 @@ import debounce from "lodash.debounce";
 import styled from "styled-components";
 import { useEffect, useMemo, useState } from "react";
 
+const maximumCharacters = 3;
+
 const QuantitySelectorRoot = styled.div`
   position: relative;
+
+  input {
+    box-sizing: content-box;
+    text-align: center;
+    width: ${maximumCharacters}ch;
+  }
 `;
 
 /**
@@ -38,6 +46,10 @@ const QuantitySelector = ({ onChange, value }) => {
   };
 
   const handleChange = (e) => {
+    // Prevent more than 3
+    if (e.target.value.length > maximumCharacters) {
+      return;
+    }
     updateValue(e.target.value);
   };
 
@@ -52,7 +64,15 @@ const QuantitySelector = ({ onChange, value }) => {
     if (newValue <= 0) {
       return updateValue("1");
     }
-    updateValue(String(newValue));
+
+    let newValueStr = String(newValue);
+    if (newValueStr.length > maximumCharacters) {
+      newValueStr = "9";
+      for (let i = 1; i < maximumCharacters; i++) {
+        newValueStr += "9";
+      }
+    }
+    updateValue(newValueStr);
   };
 
   /**

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -1,0 +1,75 @@
+import PropTypes from "prop-types";
+import debounce from "lodash.debounce";
+import styled from "styled-components";
+import { useEffect, useMemo, useState } from "react";
+
+const QuantitySelectorRoot = styled.div`
+  position: relative;
+`;
+
+/**
+ * @param {string} value
+ */
+const isValidValue = (value) => {
+  return /^\d+$/.test(value);
+};
+
+/**
+ * @param {{
+ *   onChange: (newValue) => void;
+ *   value: number;
+ * }} props
+ * @returns
+ */
+const QuantitySelector = ({ onChange, value }) => {
+  const debouncedOnChange = useMemo(() => debounce(onChange, 500), [onChange]);
+
+  const [currentValue, setCurrentValue] = useState(String(value));
+
+  useEffect(() => {
+    setCurrentValue(String(value));
+  }, [value]);
+
+  const updateValue = (newValue) => {
+    setCurrentValue(newValue);
+    if (isValidValue(newValue)) {
+      debouncedOnChange(parseInt(newValue));
+    }
+  };
+
+  const handleChange = (e) => {
+    updateValue(e.target.value);
+  };
+
+  const handleButtonClick = (modifier) => {
+    if (!isValidValue(currentValue)) {
+      updateValue("1");
+      return;
+    }
+    const parsedValue = parseInt(currentValue, 10);
+    updateValue(String(parsedValue + modifier));
+  };
+
+  return (
+    <QuantitySelectorRoot>
+      <button type="button" onClick={() => handleButtonClick(-1)}>
+        -
+      </button>
+      <input type="text" value={currentValue} onChange={handleChange} />
+      <button type="button" onClick={() => handleButtonClick(1)}>
+        +
+      </button>
+    </QuantitySelectorRoot>
+  );
+};
+
+QuantitySelector.defaultProps = {
+  value: 1,
+};
+
+QuantitySelector.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.number.isRequired,
+};
+
+export default QuantitySelector;

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -87,6 +87,8 @@ const QuantitySelector = ({ onChange, value }) => {
       return;
     } else if (event.ctrlKey && event.key === "a") {
       return;
+    } else if (/arrow(left|right)/i.test(event.key)) {
+      return;
     }
     event.preventDefault();
   };

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -43,11 +43,16 @@ const QuantitySelector = ({ onChange, value }) => {
 
   const handleButtonClick = (modifier) => {
     if (!isValidValue(currentValue)) {
-      updateValue("1");
-      return;
+      return updateValue("1");
     }
     const parsedValue = parseInt(currentValue, 10);
-    updateValue(String(parsedValue + modifier));
+    const newValue = parsedValue + modifier;
+
+    // Prevent value going below 1
+    if (newValue <= 0) {
+      return updateValue("1");
+    }
+    updateValue(String(newValue));
   };
 
   return (

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -87,10 +87,23 @@ const QuantitySelector = ({ onChange, value }) => {
       return;
     } else if (event.ctrlKey && event.key === "a") {
       return;
-    } else if (/arrow(left|right)/i.test(event.key)) {
+    } else if (/arrow(left|right|up|down)/i.test(event.key)) {
       return;
     }
     event.preventDefault();
+  };
+
+  /**
+   * Checks if the keypress is an up or down and replicates the functionality
+   * of pressing the + or - buttons
+   * @param {React.KeyboardEvent<HTMLInputElement>} event
+   */
+  const handleUpDown = (event) => {
+    if (/arrowup/i.test(event.key)) {
+      handleButtonClick(1);
+    } else if (/arrowdown/i.test(event.key)) {
+      handleButtonClick(-1);
+    }
   };
 
   return (
@@ -102,7 +115,10 @@ const QuantitySelector = ({ onChange, value }) => {
         type="text"
         value={currentValue}
         onChange={handleChange}
-        onKeyDown={filterKeyPresses}
+        onKeyDown={(e) => {
+          filterKeyPresses(e);
+          handleUpDown(e);
+        }}
       />
       <button type="button" onClick={() => handleButtonClick(1)}>
         +

--- a/react-app/src/components/cart/QuantitySelector.js
+++ b/react-app/src/components/cart/QuantitySelector.js
@@ -55,12 +55,33 @@ const QuantitySelector = ({ onChange, value }) => {
     updateValue(String(newValue));
   };
 
+  /**
+   * Prevents keys from trigering a change unless they are considered valid.
+   * If the key/key combination pressed is not valid, the event is prevented.
+   * @param {React.KeyboardEvent<HTMLInputElement>} event
+   */
+  const filterKeyPresses = (event) => {
+    if (/\d/.test(event.key)) {
+      return;
+    } else if (/(backspace|tab)/i.test(event.code)) {
+      return;
+    } else if (event.ctrlKey && event.key === "a") {
+      return;
+    }
+    event.preventDefault();
+  };
+
   return (
     <QuantitySelectorRoot>
       <button type="button" onClick={() => handleButtonClick(-1)}>
         -
       </button>
-      <input type="text" value={currentValue} onChange={handleChange} />
+      <input
+        type="text"
+        value={currentValue}
+        onChange={handleChange}
+        onKeyDown={filterKeyPresses}
+      />
       <button type="button" onClick={() => handleButtonClick(1)}>
         +
       </button>

--- a/react-app/src/components/common/Paper.js
+++ b/react-app/src/components/common/Paper.js
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 
 const roundedEdges = css`
-  border-radius: ${(props) => props.theme.borderRadius}px;
+  border-radius: ${(props) => props.theme.borderRadius.main}px;
 `;
 
 const Paper = styled.div`

--- a/react-app/src/store/cart-items.js
+++ b/react-app/src/store/cart-items.js
@@ -39,6 +39,28 @@ export const addCartItem = createAsyncThunk(
   }
 );
 
+export const changeCartItemQuantity = createAsyncThunk(
+  "cartItems/changeCartItemQuantity",
+  async ({ itemId, quantity }, thunkAPI) => {
+    const response = await fetch(`/api/cart/${itemId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ quantity }),
+    });
+
+    if (response.ok) {
+      return await response.json();
+    } else if (response.status < 500) {
+      const data = await response.json();
+      throw thunkAPI.rejectWithValue(data.errors);
+    } else {
+      throw thunkAPI.rejectWithValue(["An error occurred. Please try again."]);
+    }
+  }
+);
+
 export const removeCartItem = createAsyncThunk(
   "cartItems/removeItem",
   async (itemId, thunkAPI) => {
@@ -94,6 +116,10 @@ const cartItemsSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchCartItems.fulfilled, cartItemsAdapter.upsertMany);
     builder.addCase(addCartItem.fulfilled, cartItemsAdapter.addOne);
+    builder.addCase(
+      changeCartItemQuantity.fulfilled,
+      cartItemsAdapter.updateOne
+    );
     builder.addCase(removeCartItem.fulfilled, (state, action) => {
       cartItemsAdapter.removeOne(state, action.payload.id);
     });

--- a/react-app/src/store/cart-items.js
+++ b/react-app/src/store/cart-items.js
@@ -115,7 +115,7 @@ const cartItemsSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(fetchCartItems.fulfilled, cartItemsAdapter.upsertMany);
-    builder.addCase(addCartItem.fulfilled, cartItemsAdapter.addOne);
+    builder.addCase(addCartItem.fulfilled, cartItemsAdapter.upsertOne);
     builder.addCase(
       changeCartItemQuantity.fulfilled,
       cartItemsAdapter.updateOne

--- a/react-app/src/theme/index.js
+++ b/react-app/src/theme/index.js
@@ -3,6 +3,7 @@ const theme = {
   backgroundColor: "#fff",
   borderRadius: {
     main: 6,
+    button: 24,
   },
   divider: "rgba(0, 0, 0, 0.12)",
   transitions: {

--- a/react-app/src/theme/index.js
+++ b/react-app/src/theme/index.js
@@ -1,7 +1,9 @@
 const theme = {
   color: "#000",
   backgroundColor: "#fff",
-  borderRadius: 6,
+  borderRadius: {
+    main: 6,
+  },
   divider: "rgba(0, 0, 0, 0.12)",
   transitions: {
     easing: {


### PR DESCRIPTION
This adds the ability for users to adjust the quantity of an item in their cart. This introduces a `QuantitySelector` component which I believe can be reused for use on the item's page as well.

This closes #13 

This also alters the `theme`'s `borderRadius` property. Instead of it being a value, it is now an object. The previous value is now found under `theme.borderRadius.main`. I've updated all uses that exist in my branch. Usage in #70 will need to be updated accordingly.