### PR TITLE
Fix instances of using class instead of className

### DIFF
--- a/react-app/src/components/cart/CartButton.js
+++ b/react-app/src/components/cart/CartButton.js
@@ -8,7 +8,7 @@ const CartButton = ({ className }) => {
   return (
     <>
       <IconButton className={className} onClick={cart.show}>
-        <i class="fas fa-shopping-cart" id="cart-icon"></i>
+        <i className="fas fa-shopping-cart" id="cart-icon" />
       </IconButton>
       <CartDrawer />
     </>

--- a/react-app/src/components/cart/CartDrawer.js
+++ b/react-app/src/components/cart/CartDrawer.js
@@ -210,7 +210,7 @@ const CartDrawer = () => {
           <div className="inner">
             <div className="close-button-wrapper">
               <IconButton onClick={() => cart.hide()}>
-                <i class="fas fa-times" />
+                <i className="fas fa-times" />
               </IconButton>
             </div>
             <div>


### PR DESCRIPTION
This fixes instances in the code where `class` was used as a property when defining classes for the element instead of `className`.