### PR TITLE
Redirect to home when attempting to visit restricted page

### DIFF
--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -8,6 +8,7 @@ import NavBar from "./components/NavBar";
 import ItemPage from "./components/items/ItemPage";
 import HomePage from "./components/HomePage";
 import NewItemPage from "./components/items/NewItemPage";
+import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Results from "./components/search/Results";
 import { authenticate } from "./store/session";
 import Footer from "./components/Footer";
@@ -33,9 +34,9 @@ function App() {
         <CartProvider>
           <NavBar />
           <Switch>
-            <Route path="/items/new">
+            <ProtectedRoute path="/items/new">
               <NewItemPage />
-            </Route>
+            </ProtectedRoute>
             <Route path="/items/:itemId">
               <ItemPage />
             </Route>

--- a/react-app/src/components/auth/ProtectedRoute.js
+++ b/react-app/src/components/auth/ProtectedRoute.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { Route, Redirect } from "react-router-dom";
+
+const ProtectedRoute = (props) => {
+  const user = useSelector((state) => state.session.user);
+
+  return (
+    <Route {...props}>{user ? props.children : <Redirect to="/" />}</Route>
+  );
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
When singing out on the Sell Item page, the user remains on the page even once logged out. I've re-implemented the `ProtectedRoute` component to automatically redirect the user to the home page if they attempt to access a page when they are not logged in.